### PR TITLE
Adds a new method to Builder

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -53,7 +53,7 @@ Builder.prototype.withRequestOptions = function(options) {
 
 // This function adds new options on top of existing options
 Builder.prototype.addRequestOptions = function(options) {
-	function MergeRecursive(obj1, obj2) {
+	function mergeRecursive(obj1, obj2) {
 		for (var p in obj2) {
 			if (!obj2.hasOwnProperty(p)) {
 				continue;
@@ -61,7 +61,7 @@ Builder.prototype.addRequestOptions = function(options) {
 			try {
 				// Property in destination object set; update its value.
 				if ( obj2[p].constructor===Object ) {
-					MergeRecursive(obj1[p], obj2[p]);
+					mergeRecursive(obj1[p], obj2[p]);
 				} else {
 					obj1[p] = obj2[p];
 				}
@@ -73,9 +73,9 @@ Builder.prototype.addRequestOptions = function(options) {
 
 		return obj1;
 	}
-	MergeRecursive(this.request.options, options);
+	mergeRecursive(this.request.options, options);
 	this.walker.request.options = this.request.options;
-	return this
+	return this;
 };
 
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -56,29 +56,25 @@ Builder.prototype.addRequestOptions = function(options) {
 	function MergeRecursive(obj1, obj2) {
 		for (var p in obj2) {
 			if (!obj2.hasOwnProperty(p)) {
-				continue
+				continue;
 			}
 			try {
 				// Property in destination object set; update its value.
-				if ( obj2[p].constructor==Object ) {
-					obj1[p] = MergeRecursive(obj1[p], obj2[p]);
-
+				if ( obj2[p].constructor===Object ) {
+					MergeRecursive(obj1[p], obj2[p]);
 				} else {
 					obj1[p] = obj2[p];
-
 				}
-
 			} catch(e) {
 				// Property in destination object not set; create it and set its value.
 				obj1[p] = obj2[p];
-
 			}
 		}
 
 		return obj1;
 	}
-	MergeRecursive(this.request.options, options)
-	this.walker.request.options = this.request.options
+	MergeRecursive(this.request.options, options);
+	this.walker.request.options = this.request.options;
 	return this
 };
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -45,10 +45,43 @@ Builder.prototype.withTemplateParameters = function(parameters) {
   return this;
 };
 
+// This function resets any previous set options
 Builder.prototype.withRequestOptions = function(options) {
   this.walker.request = this.request = standardRequest.defaults(options);
   return this;
 };
+
+// This function adds new options on top of existing options
+Builder.prototype.addRequestOptions = function(options) {
+	function MergeRecursive(obj1, obj2) {
+		for (var p in obj2) {
+			if (!obj2.hasOwnProperty(p)) {
+				continue
+			}
+			try {
+				// Property in destination object set; update its value.
+				if ( obj2[p].constructor==Object ) {
+					obj1[p] = MergeRecursive(obj1[p], obj2[p]);
+
+				} else {
+					obj1[p] = obj2[p];
+
+				}
+
+			} catch(e) {
+				// Property in destination object not set; create it and set its value.
+				obj1[p] = obj2[p];
+
+			}
+		}
+
+		return obj1;
+	}
+	MergeRecursive(this.request.options, options)
+	this.walker.request.options = this.request.options
+	return this
+};
+
 
 Builder.prototype.withRequestLibrary = function(request) {
   this.walker.request = this.request = request;


### PR DESCRIPTION
The problem with the current library is that you cannot specify options separately.
I have use cases where I would like to set something like an Authorization header
when creating a new request and then later add more options (query strings, additional
headers, etc.).  This adds a new method (therefore making it backward compatible)
that specifically allows more options to be added rather than starting from scratch.