### PR TITLE
This gracefully handles requests with now 'follows' in them

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -14,6 +14,7 @@ var log = minilog('traverson');
 function Builder(mediaType, startUri) {
   var adapter = this.createAdapter(mediaType);
   this.walker = new Walker(adapter);
+  this.walker.links = [];
   this.walker.startUri = startUri;
   this.walker.request = this.request = standardRequest;
   this.walker.parseJson = JSON.parse;


### PR DESCRIPTION
The issue here is that a 'normal' request will follow relations.  But there are cases
(e.g., getting information about the root URI or creating a request based on a Location
header) where no relation needs to be followed.  Currently, traverson requires an
empty 'follow()' invocation or it fails.  This simple fix eliminates the requirement
for this empty call.