### PR TITLE
LinkHeader: remove dependency with parse-link-header

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -22,7 +22,7 @@ var checkHttpStatus = require('./transforms/check_http_status')
   , executeLastHttpRequest = require('./transforms/execute_last_http_request')
   , executeHttpRequest = require('./transforms/execute_http_request')
   , parse = require('./transforms/parse')
-  , parseLinkHeader = require('./transforms/parse_link_header');
+  , parseLinkHeader = require('./transforms/parse_link_header').parseLinkHeader;
 
 /**
  * Starts the link traversal process and end it with an HTTP get.

--- a/lib/json_adapter.js
+++ b/lib/json_adapter.js
@@ -2,12 +2,12 @@
 
 var jsonpath = require('jsonpath-plus')
   , minilog = require('minilog')
-  , _s = require('underscore.string')
-  , parse = require('parse-link-header');
+  , _s = require('underscore.string');
 
 var errorModule = require('./errors')
   , errors = errorModule.errors
-  , createError = errorModule.createError;
+  , createError = errorModule.createError
+  , parse = require('./transforms/parse_link_header').parse;
 
 function JsonAdapter(log) {
   this.log = log;

--- a/lib/transforms/parse_link_header.js
+++ b/lib/transforms/parse_link_header.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var parse = require('parse-link-header')
+var xtend = require('xtend')
   , minilog = require('minilog')
   , log = minilog('traverson');
 
@@ -27,4 +27,49 @@ function handleError(t, e) {
   log.error('parsing failed');
   log.error(error);
   t.callback(error);
+}
+
+function hasRel(x) {
+  return x && x.rel;
+}
+
+function intoRels (acc, x) {
+  function splitRel (rel) {
+    acc[rel] = xtend(x, { rel: rel });
+  }
+
+  x.rel.split(/\s+/).forEach(splitRel);
+
+  return acc;
+}
+
+function createObjects (acc, p) {
+  // rel="next" => 1: rel 2: next
+  var m = p.match(/\s*(.+)\s*=\s*"?([^"]+)"?/);
+  if (m) acc[m[1]] = m[2];
+  return acc;
+}
+
+function parseLink(link) {
+  try {
+    var parts     =  link.split(';')
+      , linkUrl   =  parts.shift().replace(/[<>]/g, '');
+
+    var info = parts
+      .reduce(createObjects, {});
+
+    info.url = linkUrl;
+    return info;
+  } catch (e) {
+    return null;
+  }
+}
+
+function parse(linkHeader) {
+  if (!linkHeader) return null;
+
+  return linkHeader.split(/,\s*</)
+   .map(parseLink)
+   .filter(hasRel)
+   .reduce(intoRels, {});
 }

--- a/lib/transforms/parse_link_header.js
+++ b/lib/transforms/parse_link_header.js
@@ -8,7 +8,12 @@ var errorModule = require('../errors')
   , errors = errorModule.errors
   , createError = errorModule.createError;
 
-module.exports = function parseLinkHeader(t) {
+module.exports = {
+  parseLinkHeader: parseLinkHeader,
+  parse: parse
+};
+
+function parseLinkHeader(t) {
   if (!t.step.doc ||
       !t.step.response ||
       !t.step.response.headers ||
@@ -24,7 +29,7 @@ module.exports = function parseLinkHeader(t) {
     handleError(t, e);
     return false;
   }
-};
+}
 
 function handleError(t, e) {
   var error = e;
@@ -39,11 +44,10 @@ function hasRel(x) {
 
 function intoRels (acc, x) {
   function splitRel (rel) {
-    acc[rel] = xtend(x, { rel: rel });
+    acc[rel] = xtend(x, {rel: rel});
   }
 
   x.rel.split(/\s+/).forEach(splitRel);
-
   return acc;
 }
 
@@ -69,7 +73,7 @@ function parseLink(link) {
   }
 }
 
-function parse(linkHeader) {
+function parse (linkHeader) {
   if (!linkHeader) return null;
 
   return linkHeader.split(/,\s*</)

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "superagent": "^3.3.1",
     "underscore.string": "^3.3.4",
     "url-template": "^2.0.4",
-    "parse-link-header": "^0.4.1"
+    "xtend": "~4.0.0"
   },
   "devDependencies": {
     "brfs": "^1.1.1",


### PR DESCRIPTION
PR related to https://github.com/basti1302/traverson/issues/86

We have embedded the `parse-link-header` code in our `transformations/parse_link_header.js` by omitting the querystring parse. This allows us to remove dependencies with url and querystring therefore decreasing the final size.

Thoughts?